### PR TITLE
Fix AsyncStorage import

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   "dependencies": {
     "react": "17.0.2",
     "react-native": "^0.64.0",
-    "react-native-root-siblings": "^3.2.1"
+    "react-native-root-siblings": "^3.2.1",
+    "@react-native-async-storage/async-storage": "^1.19.3"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.3",

--- a/src/AvoDebugger.js
+++ b/src/AvoDebugger.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import {Animated, TouchableOpacity, Platform, Settings, AsyncStorage} from 'react-native';
+import {Animated, TouchableOpacity, Platform, Settings} from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import {Component} from 'react';
 import RootSiblings from 'react-native-root-siblings';
 import EventsListScreen from './eventslistscreen/EventsListScreen';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1367,6 +1367,13 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@react-native-async-storage/async-storage@^1.19.3":
+  version "1.19.3"
+  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.19.3.tgz#ad5fe3ed0a82d4624aa4500321c1e09c02daeb46"
+  integrity sha512-CwGfoHCWdPOTPS+2fW6YRE1fFBpT9++ahLEroX5hkgwyoQ+TkmjOaUxixdEIoVua9Pz5EF2pGOIJzqOTMWfBlA==
+  dependencies:
+    merge-options "^3.0.4"
+
 "@react-native-community/cli-debugger-ui@^5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-5.0.1.tgz#6b1f3367b8e5211e899983065ea2e72c1901d75f"
@@ -3918,6 +3925,11 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+is-plain-obj@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
+  integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
+
 is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -4858,6 +4870,13 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+merge-options@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-3.0.4.tgz#84709c2aa2a4b24c1981f66c179fe5565cc6dbb7"
+  integrity sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==
+  dependencies:
+    is-plain-obj "^2.1.0"
 
 merge-stream@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixes #48 

AsyncStorage has been removed from the latest react-native versions giving the following error when using `react-native-analytics-debugger`:

```
 ERROR  Invariant Violation: AsyncStorage has been removed from react-native core. It can now be installed and imported from '@react-native-async-storage/async-storage' instead of 'react-native'. See https://github.com/react-native-async-storage/async-storage, js engine: hermes
```

This PR replaces the `AsyncStorage` import from `react-native` with  `@react-native-async-storage/async-storage` as suggested by the error.