### PR TITLE
Fix flatted prototype pollution (GHSA #154)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "resolutions": {
     "cross-spawn": "^7.0.5",
     "on-headers": "^1.1.0",
-    "tmp": "^0.2.4"
+    "tmp": "^0.2.4",
+    "flatted": "^3.4.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3382,15 +3382,10 @@ flat-cache@^3.0.4:
     keyv "^4.5.3"
     rimraf "^3.0.2"
 
-flatted@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
-  integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
-
-flatted@^3.2.9:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.1.tgz#21db470729a6734d4997002f439cb308987f567a"
-  integrity sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
+flatted@^2.0.0, flatted@^3.2.9, flatted@^3.4.2:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.2.tgz#f5c23c107f0f37de8dbdf24f13722b3b98d52726"
+  integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
 
 flow-enums-runtime@^0.0.5:
   version "0.0.5"


### PR DESCRIPTION
## Summary
- Force `flatted` to `^3.4.2` via yarn `resolutions` to patch the prototype-pollution vulnerability in `parse()` (Dependabot alert #154).
- The vulnerable `flatted@2.0.2` was pinned transitively by `eslint@6.8.0 → flat-cache@2.0.1`. Dependabot couldn't auto-resolve it because `flat-cache@2` declares `flatted@^2.0.0`, but `flat-cache` only uses `flatted.parse`/`stringify`, which remain compatible in 3.x.
- Devkit-only chain (eslint), so no runtime impact on consumers.

## Test plan
- [x] `yarn install` succeeds and `yarn.lock` resolves `flatted` to `3.4.2`
- [x] `npx eslint src` runs without flatted-related errors
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)